### PR TITLE
revert outgoing message dropping logic

### DIFF
--- a/src/out_queue.rs
+++ b/src/out_queue.rs
@@ -85,7 +85,7 @@ impl OutQueue {
 /// Checks if given message queue should not be dropped.
 fn is_queue_valid(priority: u8, queue: &VecDeque<(Instant, Vec<u8>)>, conf: &SocketConfig) -> bool {
     priority < conf.msg_drop_priority || // Don't drop high-priority messages.
-    queue.front().map_or(false, |&(ref timestamp, _)| {
+    queue.front().map_or(true, |&(ref timestamp, _)| {
         timestamp.elapsed().as_secs() <= conf.max_msg_age_secs
     })
 }
@@ -114,14 +114,14 @@ mod tests {
             use std::ops::Sub;
 
             #[test]
-            fn it_returns_false_when_queue_is_empty() {
+            fn it_returns_true_when_queue_is_empty() {
                 let mut conf = SocketConfig::default();
                 conf.msg_drop_priority = 2;
                 let queue = VecDeque::new();
 
                 let retain = is_queue_valid(2, &queue, &conf);
 
-                assert!(!retain);
+                assert!(retain);
             }
 
             #[test]

--- a/src/out_queue.rs
+++ b/src/out_queue.rs
@@ -76,7 +76,7 @@ impl OutQueue {
     fn expired_queues(&self) -> Vec<u8> {
         self.inner
             .iter()
-            .filter(|&(&priority, queue)| !is_queue_valid(priority, queue, &self.conf))
+            .skip_while(|&(&priority, queue)| is_queue_valid(priority, queue, &self.conf))
             .map(|(&priority, _)| priority)
             .collect()
     }
@@ -202,7 +202,9 @@ mod tests {
 
             let expired = out_queue.expired_queues();
 
-            assert_eq!(expired, vec![1, 4]);
+            // NOTE(povilas): this is unexpected behavior to me. I expected it to return [1, 4].
+            // Such behavior is required by Routing and might be changed in the future.
+            assert_eq!(expired, vec![1, 2, 3, 4]);
         }
     }
 


### PR DESCRIPTION
Background
-----------------
socket-collection outgoing data is stored in multiple queues with
different priorities. Those queues are ordered by priorities.
Every message also has a timestamp and could expire. socket-collection
drops queues with expired messages.

Expired queues
----------------------
The whole queue is considered expired, if it's first message got
expired. Then socket-collection will drop expired outgoing queues.
The way it collects expired queues might be unexpected: it doesn't
filter all queues that got expired, but instead iterates trough
all queues in order by priority, skips not expired queues, finds
the first expired one and drops it together with all queues with
subsequent priorities.