### PR TITLE
resolves #11: implement socket trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,5 +72,9 @@ quick_error! {
             display("Crypto related error: {}", e)
             from()
         }
+        /// Some operation is invalid in the given context.
+        InvalidOperation {
+            display("Operation not permitted")
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,5 +152,5 @@ pub trait Socket {
     fn set_linger(&self, dur: Option<Duration>) -> ::Res<()>;
 
     /// Return the wrapped mio socket.
-    fn into_underlying_sock(self) -> ::Res<Self::Inner>;
+    fn into_inner(self) -> ::Res<Self::Inner>;
 }

--- a/src/tcp_sock.rs
+++ b/src/tcp_sock.rs
@@ -175,7 +175,7 @@ impl Socket for TcpSock {
     }
 
     /// Retrieve the wrapped mio `TcpStream`.
-    fn into_underlying_sock(mut self) -> ::Res<Self::Inner> {
+    fn into_inner(mut self) -> ::Res<Self::Inner> {
         let inner = self.inner.take().ok_or(SocketError::UninitialisedSocket)?;
         Ok(inner.stream)
     }
@@ -183,7 +183,7 @@ impl Socket for TcpSock {
 
 // NOTE: ideally, we would implement `Drop` for `Inner` which actually owns the `TcpStream` so it's
 // natural that it should finalize it as well. Unfortunately, we cannot move `Inner.stream` out in
-// `TcpSock::into_underlying_sock()` in such case. Since `Inner` is not exposed publicly, this
+// `TcpSock::into_inner()` in such case. Since `Inner` is not exposed publicly, this
 // design should successfully finalize TCP socket too.
 impl Drop for TcpSock {
     fn drop(&mut self) {

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -204,7 +204,7 @@ impl Socket for UdpSock {
     }
 
     /// Retrieve the wrapped mio `UdpSocket`.
-    fn into_underlying_sock(mut self) -> ::Res<Self::Inner> {
+    fn into_inner(mut self) -> ::Res<Self::Inner> {
         let inner = self.inner.take().ok_or(SocketError::UninitialisedSocket)?;
         Ok(inner.sock)
     }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -7,7 +7,7 @@ extern crate socket_collection;
 use mio::net::TcpListener;
 use mio::{Events, Poll, PollOpt, Ready, Token};
 use rand::Rng;
-use socket_collection::{SocketError, TcpSock};
+use socket_collection::{Socket, SocketError, TcpSock};
 
 #[test]
 fn data_transfer_up_to_2_mb() {

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -11,7 +11,7 @@ use hamcrest2::prelude::*;
 use maidsafe_utilities::thread;
 use mio::*;
 use mio_extras::timer::Timer;
-use socket_collection::UdpSock;
+use socket_collection::{Socket, UdpSock};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};


### PR DESCRIPTION
Defines protocol agnostic Socket trait and implements it for `TcpSock` and `UdpSock`. This trait should increase code reusability.