### PR TITLE
fix TCP message decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # socket-collection - Change Log
 
+## Unknown
+
+* Fixed TcpSock::read() when multiple messages are buffered.
+
 ## [0.4.0]
 
 * Removed UDT support.


### PR DESCRIPTION
When data is read from socket, it is buffered. There might be multiple messages buffered at once.
Even in such case TcpSock::read() should try to decrypt a single message whose length is known
by the header. Unfortunately, that was not the case: read() attempted to decrypt a whole buffer
and would fail utterly.

This fix makes sure we respect the message boundaries before trying to decrypt it.