### PR TITLE
Use latest stable rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ os:
   - osx
   - windows
 language: rust
-rust:
-  - 1.31.0
 sudo: false
 cache:
   cargo: true
@@ -16,18 +14,12 @@ before_script:
   - if ! cargo prune --version | grep -q "0.1.8"; then
       cargo install cargo-prune --vers="0.1.8" --force;
     fi
-  - if ! rustfmt --version | grep -q "1.0.0-stable"; then
-      rustup component add rustfmt;
-    fi
-  - if ! cargo clippy --version | grep -q "0.0.212"; then
-      rustup component add clippy;
-    fi
+  - rustup component add rustfmt clippy
 script:
   - cargo fmt -- --check &&
     cargo test --verbose --release
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then
-      cargo clippy --verbose --release &&
-      cargo clippy --verbose --release --profile=test ;
+      cargo clippy --verbose --release --all-targets ;
     fi
 before_cache:
   - cargo prune


### PR DESCRIPTION
Now when rustmft and clippy got stabilized, it's safe to update them, cause they promise
not to break our builds :)